### PR TITLE
remove "push on main" trigger

### DIFF
--- a/.github/workflows/check_url_screen.yml
+++ b/.github/workflows/check_url_screen.yml
@@ -1,6 +1,4 @@
 on:
-  push:
-    branches: main
   schedule:
     - cron: '0 0 1 * *'
 


### PR DESCRIPTION
In the github action added in the previous PR, the triggers were both the shedule and the push on the main branch, whereas it should only be the schedule (run once per month). This PR corrects that. #33