### PR TITLE
implement "filter by category" in the showcase

### DIFF
--- a/js/filter-buttons.js
+++ b/js/filter-buttons.js
@@ -1,0 +1,47 @@
+filterSelection("all")
+function filterSelection(c) {
+  var x, i;
+  x = document.getElementsByClassName("filterDiv");
+  if (c == "all") c = "";
+  // Add the "show" class (display:block) to the filtered elements, and remove the "show" class from the elements that are not selected
+  for (i = 0; i < x.length; i++) {
+    w3RemoveClass(x[i], "show");
+    if (x[i].className.indexOf(c) > -1) w3AddClass(x[i], "show");
+  }
+}
+
+// Show filtered elements
+function w3AddClass(element, name) {
+  var i, arr1, arr2;
+  arr1 = element.className.split(" ");
+  arr2 = name.split(" ");
+  for (i = 0; i < arr2.length; i++) {
+    if (arr1.indexOf(arr2[i]) == -1) {
+      element.className += " " + arr2[i];
+    }
+  }
+}
+
+// Hide elements that are not selected
+function w3RemoveClass(element, name) {
+  var i, arr1, arr2;
+  arr1 = element.className.split(" ");
+  arr2 = name.split(" ");
+  for (i = 0; i < arr2.length; i++) {
+    while (arr1.indexOf(arr2[i]) > -1) {
+      arr1.splice(arr1.indexOf(arr2[i]), 1);
+    }
+  }
+  element.className = arr1.join(" ");
+}
+
+// Add active class to the current control button (highlight it)
+var btnContainer = document.getElementById("myBtnContainer");
+var btns = btnContainer.getElementsByClassName("btn");
+for (var i = 0; i < btns.length; i++) {
+  btns[i].addEventListener("click", function() {
+    var current = document.getElementsByClassName("active");
+    current[0].className = current[0].className.replace(" active", "");
+    this.className += " active";
+  });
+}

--- a/showcase.Rmd
+++ b/showcase.Rmd
@@ -26,8 +26,49 @@ source(file.path("R", "functions.R"))
 ```{r build-content, include=FALSE}
 sites <- clean_sites(read_csv("sites.csv"), params$check_url)
 update_screenshots(sites, params$update_all)
-rmd_chunks <- make_rmd_chunks(sites, image_width = 600)
+rmd_chunks <- make_showcase_chunks(sites, image_width = 600)
+button_filters <- buttons_filter(sites)
 ```
 
-```{r insert-showcase, child = rmd_chunks}
+```{r insert-showcase, child = c(button_filters, rmd_chunks)}
 ```
+
+```{css}
+
+.filterDiv {
+  display: none; /* Hidden by default */
+}
+
+/* The "show" class is added to the filtered elements */
+.show {
+  display: block;
+}
+
+/* Style the buttons */
+.btn {
+  border: none;
+  outline: none;
+  padding: 12px 16px;
+  color: white;
+  background-color: var(--bkgd-color, #0F2E3D);
+  cursor: pointer;
+}
+
+/* Add a light grey background on mouse-over */
+.btn:hover {
+  background-color: #143d52;
+  color: white
+}
+
+/* Add a dark background to the active button */
+.btn.active {
+  background-color: #1e5c7b;
+  color: white;
+}
+
+.icon-link {
+  font-size: 0.7rem;
+}
+```
+
+<script src = "js/filter-buttons.js"></script>

--- a/sites.csv
+++ b/sites.csv
@@ -1,39 +1,39 @@
-name,url,source
-John Paul Helveston,https://jhelvy.github.io/,https://github.com/jhelvy/jhelvy.github.io/
-The Mockup Blog,https://themockup.netlify.app/,https://github.com/jthomasmock/radix_themockup
-Lisa Lendway,https://lisalendway.netlify.app/,https://github.com/llendway/lisalendway_distill
-Emi Tanaka,https://emitanaka.org/,https://github.com/emitanaka/emitanaka.github.io
-Ijeamaka Anyene,https://ijeamaka-anyene.netlify.app/,https://github.com/Ijeamakaanyene/ijeamaka-anyene
-Before I Sleep,https://milesmcbain.xyz/,https://github.com/MilesMcBain/milesmcbain.com/
-Piping Hot Data,https://www.pipinghotdata.com/,https://github.com/shannonpileggi/pipinghotdata_distill
-The Scrapbook,https://eliocamp.github.io/scrapbook/,https://github.com/eliocamp/scrapbook
-June Choe,https://yjunechoe.github.io/,https://github.com/yjunechoe/yjunechoe.github.io
-Alex K. Gold,https://alexkgold.space/,https://github.com/akgold/akg_site
-Sciencificity Blog,https://sciencificity-blog.netlify.app/,https://github.com/sciencificity/Blog_Vebash
-R-Vogg-Blog,https://r-vogg-blog.netlify.app/,https://github.com/richardvogg/r-vogg-blog
-Sharing Your Work with xaringan,https://spcanelon.github.io/xaringan-basics-and-beyond,https://github.com/spcanelon/xaringan-basics-and-beyond
-jeremydata,https://jeremydata.com/,https://github.com/jeremy-allen/jeremydata_blog
-Jannik Buhr,https://jmbuhr.de,https://github.com/jmbuhr/jmbuhr.github.io
-Harry Fisher,https://hfshr.xyz,https://github.com/hfshr/distill_blog
-Serdar Balcı,https://www.serdarbalci.com/,https://github.com/sbalci/sbalci.github.io/
-Umair Durrani,https://udurrani.netlify.app/,https://github.com/durraniu/udurrani_distill
-Kaija Gahm,https://kaijagahm.netlify.app/,https://github.com/kaijagahm/kaija_bean
-Max Rohde,https://maximilianrohde.com,https://github.com/maxdrohde/blog
-LiteralFightNerd,https://literalfightnerd.com/,https://github.com/NateLatshaw/LiteralFightNerd
-Joseph Casillas,https://www.jvcasillas.com/,https://github.com/jvcasillas/jvcasillas.github.io
-Sean Angiolillo,https://sean.rbind.io,https://github.com/seanangio/distill_blog
-Data Sci Dani,https://datascidani.com/,https://github.com/danielle-b/datascidani2
-Open Source Football,https://www.opensourcefootball.com/,https://github.com/mrcaseb/open-source-football
-Westchester Covid-19 Tracking,https://westchester-covid.mattherman.info/,https://github.com/mfherman/westchester-covid
-Miha Gazvoda,https://mihagazvoda.com/,https://github.com/mihagazvoda/mihagazvoda.com
-Etienne Bacher,https://www.etiennebacher.com/,https://github.com/etiennebacher/personal_website_distill
-Beatriz Milz,https://beatrizmilz.com/,https://github.com/beatrizmilz/blog
-Associação Brasileira de Jurimetria,https://lab.abj.org.br/,https://github.com/abjur/blog
-Kyle Cuilla,https://kcanalytics.netlify.app/,https://github.com/kcuilla/kc_analytics
-Southern California R Users Groups,https://socalr.org/,https://github.com/laRusers/socalr.org
-werk.statt.codes,https://werk.statt.codes/,https://github.com/werkstattcodes/distill_clean
-Lore Abad,https://loreabad6.github.io/,https://github.com/loreabad6/loreabad6.github.io
-Eric Ekholm,https://www.ericekholm.com/,https://github.com/ekholme/ee-website
-Pedro J. Pérez,https://perezp44.github.io/pjperez.web/01_blog.html,https://github.com/perezp44/pjperez.web
-Ted Laderas,https://laderast.github.io,https://github.com/laderast/laderast.github.io
-Bayesian statistics with R,https://oliviergimenez.github.io/bayesian-stats-with-R/,https://github.com/oliviergimenez/bayesian-stats-with-R
+name,url,source,postcard,academic,darkmode
+John Paul Helveston,https://jhelvy.github.io/,https://github.com/jhelvy/jhelvy.github.io/,0,0,0
+The Mockup Blog,https://themockup.netlify.app/,https://github.com/jthomasmock/radix_themockup,0,0,0
+Lisa Lendway,https://lisalendway.netlify.app/,https://github.com/llendway/lisalendway_distill,0,0,0
+Emi Tanaka,https://emitanaka.org/,https://github.com/emitanaka/emitanaka.github.io,0,0,0
+Ijeamaka Anyene,https://ijeamaka-anyene.netlify.app/,https://github.com/Ijeamakaanyene/ijeamaka-anyene,0,0,0
+Before I Sleep,https://milesmcbain.xyz/,https://github.com/MilesMcBain/milesmcbain.com/,0,0,0
+Piping Hot Data,https://www.pipinghotdata.com/,https://github.com/shannonpileggi/pipinghotdata_distill,0,0,0
+The Scrapbook,https://eliocamp.github.io/scrapbook/,https://github.com/eliocamp/scrapbook,0,0,0
+June Choe,https://yjunechoe.github.io/,https://github.com/yjunechoe/yjunechoe.github.io,0,0,0
+Alex K. Gold,https://alexkgold.space/,https://github.com/akgold/akg_site,0,0,0
+Sciencificity Blog,https://sciencificity-blog.netlify.app/,https://github.com/sciencificity/Blog_Vebash,0,0,0
+R-Vogg-Blog,https://r-vogg-blog.netlify.app/,https://github.com/richardvogg/r-vogg-blog,0,0,0
+Sharing Your Work with xaringan,https://spcanelon.github.io/xaringan-basics-and-beyond,https://github.com/spcanelon/xaringan-basics-and-beyond,0,0,0
+jeremydata,https://jeremydata.com/,https://github.com/jeremy-allen/jeremydata_blog,0,0,0
+Jannik Buhr,https://jmbuhr.de,https://github.com/jmbuhr/jmbuhr.github.io,0,0,1
+Harry Fisher,https://hfshr.xyz,https://github.com/hfshr/distill_blog,0,0,0
+Serdar Balcı,https://www.serdarbalci.com/,https://github.com/sbalci/sbalci.github.io/,0,0,0
+Umair Durrani,https://udurrani.netlify.app/,https://github.com/durraniu/udurrani_distill,0,0,0
+Kaija Gahm,https://kaijagahm.netlify.app/,https://github.com/kaijagahm/kaija_bean,0,0,0
+Max Rohde,https://maximilianrohde.com,https://github.com/maxdrohde/blog,0,0,0
+LiteralFightNerd,https://literalfightnerd.com/,https://github.com/NateLatshaw/LiteralFightNerd,0,0,0
+Joseph Casillas,https://www.jvcasillas.com/,https://github.com/jvcasillas/jvcasillas.github.io,0,0,0
+Sean Angiolillo,https://sean.rbind.io,https://github.com/seanangio/distill_blog,0,0,0
+Data Sci Dani,https://datascidani.com/,https://github.com/danielle-b/datascidani2,0,0,0
+Open Source Football,https://www.opensourcefootball.com/,https://github.com/mrcaseb/open-source-football,0,0,0
+Westchester Covid-19 Tracking,https://westchester-covid.mattherman.info/,https://github.com/mfherman/westchester-covid,0,0,0
+Miha Gazvoda,https://mihagazvoda.com/,https://github.com/mihagazvoda/mihagazvoda.com,0,0,0
+Etienne Bacher,https://www.etiennebacher.com/,https://github.com/etiennebacher/personal_website_distill,1,1,0
+Beatriz Milz,https://beatrizmilz.com/,https://github.com/beatrizmilz/blog,0,0,0
+Associação Brasileira de Jurimetria,https://lab.abj.org.br/,https://github.com/abjur/blog,0,0,0
+Kyle Cuilla,https://kcanalytics.netlify.app/,https://github.com/kcuilla/kc_analytics,0,0,0
+Southern California R Users Groups,https://socalr.org/,https://github.com/laRusers/socalr.org,0,0,0
+werk.statt.codes,https://werk.statt.codes/,https://github.com/werkstattcodes/distill_clean,0,0,0
+Lore Abad,https://loreabad6.github.io/,https://github.com/loreabad6/loreabad6.github.io,0,0,0
+Eric Ekholm,https://www.ericekholm.com/,https://github.com/ekholme/ee-website,0,0,0
+Pedro J. Pérez,https://perezp44.github.io/pjperez.web/01_blog.html,https://github.com/perezp44/pjperez.web,0,0,0
+Ted Laderas,https://laderast.github.io,https://github.com/laderast/laderast.github.io,0,0,0
+Bayesian statistics with R,https://oliviergimenez.github.io/bayesian-stats-with-R/,https://github.com/oliviergimenez/bayesian-stats-with-R,0,0,0


### PR DESCRIPTION
As discussed in #7, it would be convenient to filter the showcase by category to keep only the examples that interest us, e.g those with darkmode, academic theme...

This PR implements this type of filters, largely building on the [w3schools example](https://www.w3schools.com/howto/howto_js_filter_elements.asp). Here's a list of additions or modifications to the code:

* I added a few categories in the CSV file, one per column with a 1/0 coding if a website has the feature. The number of categories is not limited, as long as it is placed after the first four columns. However, I think the number of categories should be limited to prevent having too many buttons at the top of the showcase (otherwise, it would need another type of selecting tool, e.g a dropdown).

* I rewrote some functions with `htmltools`. This was needed to embed the chunks more easily inside new `div`s, and I think it also makes the code cleaner and shorter (which is why I removed some functions).

There are still two drawbacks to this PR:

* the table of contents disappears. I don't know if it is compatible with having this filtering system, because the part titles (i.e the name of each website) has to be wrapped in a `div`, which (I guess) prevents the use of the ToC.

* the links to the website and its source are now below the title, and not on the right side anymore. Maybe playing with the CSS could fix that.

I tested this PR locally, but maybe you should "fork my fork" to check if it works for you too before merging this one. Also, I only put my website on the categories I created (and the one of Jannik Buhr because I remember the dark mode).