### PR TITLE
Adds jolly data blog to the showcase csv.

### DIFF
--- a/sites.csv
+++ b/sites.csv
@@ -51,3 +51,4 @@ Tidy Tales,https://tidytales.ca,https://github.com/mccarthy-m-g/tidytales,0,0,0,
 Rich Pauloo and Ryan Peek,https://r4wrds.com,https://github.com/r4wrds/r4wrds,0,1,0,1
 The Q,https://qntkhvn.netlify.app/,https://github.com/qntkhvn/qblog,1,1,0,0
 Infrequently Frequentist,https://www.infreq.com/,https://github.com/odaniel1/InfrequentlyFrequentist,0,1,0,0
+jolly data blog,https://jollydata.blog,https://github.com/nucleic-acid/jollydatablog,1,0,0,0


### PR DESCRIPTION
This adds my distill blog to the showcase list of the distillery.