### PR TITLE
Add datazoogang.de

### DIFF
--- a/sites.csv
+++ b/sites.csv
@@ -70,3 +70,4 @@ Gul Inan - Data Science Course Site,https://gulinan.github.io/mat381e/,https://g
 Avishai M Tsur,https://avishaitsur.netlify.app/,https://github.com/avishaitsur/website,0,1,0,0
 Alice Walsh,https://awalsh17.github.io/,https://github.com/awalsh17/awalsh17.github.io,0,0,0,0
 Samantha Csik,https://samanthacsik.github.io/,,1,0,0,0
+Data Zoo Gang,https://www.datazoogang.de,https://github.com/data-zoo-gang/DZG_website,0,1,0,0


### PR DESCRIPTION
I am adding the website www.datazoogang.de which I created with distill.
Of particular interest is the way I handled the page on publications: tables are generated from a single bibtex file based on keywords defined in Zotero.